### PR TITLE
Read user from variable in Ansible playbooks

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -53,6 +53,7 @@ Vagrant.configure("2") do |config|
                 ansible.compatibility_mode = "2.0"
                 ansible.playbook = "ansible-playbooks/load-balancer.yml"
                 ansible.extra_vars = {
+                    user: "vagrant",
                     hostname: "load-balancer",
                     node_ip: "172.16.3.5",
                     ansible_python_interpreter:"/usr/bin/python3"
@@ -69,6 +70,7 @@ Vagrant.configure("2") do |config|
             ansible.compatibility_mode = "2.0"
             ansible.playbook = "ansible-playbooks/master-playbook.yml"
             ansible.extra_vars = {
+                user: "vagrant",
                 n_m_nodes: N_M_NODES,
                 n_w_nodes: N_W_NODES,
                 hostname: "master-node-1",
@@ -91,6 +93,7 @@ Vagrant.configure("2") do |config|
                 ansible.compatibility_mode = "2.0"
                 ansible.playbook = "ansible-playbooks/master-replica-playbook.yml"
                 ansible.extra_vars = {
+                    user: "vagrant",
                     n_m_nodes: N_M_NODES,
                     n_w_nodes: N_W_NODES,
                     hostname: "master-node-#{i}",
@@ -112,6 +115,7 @@ Vagrant.configure("2") do |config|
                 ansible.compatibility_mode = "2.0"
                 ansible.playbook = "ansible-playbooks/worker-node.yml"
                 ansible.extra_vars = {
+                    user: "vagrant",
                     hostname: "worker-node-#{i}",
                     node_ip: "172.16.3.#{i + 99}",
                     c_eng: c_eng,

--- a/ansible-playbooks/load-balancer.yml
+++ b/ansible-playbooks/load-balancer.yml
@@ -46,9 +46,9 @@
       - docker-ce-cli=5:20.10.7~3-0~ubuntu-xenial
       - containerd.io=1.4.6-1
       
-  - name: Add vagrant user to docker group
+  - name: Add user to docker group
     user:
-      name: vagrant
+      name: "{{ user }}"
       group: docker
   
   - name: Set Docker cgroup driver to systemd

--- a/ansible-playbooks/master-playbook.yml
+++ b/ansible-playbooks/master-playbook.yml
@@ -44,9 +44,9 @@
       - containerd.io=1.4.6-1
     when: c_eng == 1
       
-  - name: Add vagrant user to docker group
+  - name: Add user to docker group
     user:
-      name: vagrant
+      name: "{{ user }}"
       group: docker
     when: c_eng == 1
   
@@ -294,12 +294,12 @@
     command: kubeadm init --control-plane-endpoint 172.16.3.5 --upload-certs --cri-socket=/var/run/crio/crio.sock --apiserver-advertise-address="{{ node_ip }}" --apiserver-cert-extra-sans="{{ node_ip }}" --node-name {{ hostname }} --pod-network-cidr=192.168.0.0/16
     when: c_eng == 3 and n_m_nodes > 1
 
-  - name: Setup kubeconfig for vagrant user
+  - name: Setup kubeconfig for user
     command: "{{ item }}"
     with_items:
-     - mkdir -p /home/vagrant/.kube
-     - cp -i /etc/kubernetes/admin.conf /home/vagrant/.kube/config
-     - chown vagrant:vagrant /home/vagrant/.kube/config
+     - "mkdir -p /home/{{ user }}/.kube"
+     - "cp -i /etc/kubernetes/admin.conf /home/{{ user }}/.kube/config"
+     - "chown {{ user }}:{{ user }} /home/{{ user }}/.kube/config"
 
 # Allow pods to run on the master node in case there are no worker nodes
   - name: Allow pods to run on the master node
@@ -367,7 +367,7 @@
   - name: Install Helm package manager (1/2)
     get_url:
       url: https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-      dest: /home/vagrant/get_helm.sh
+      dest: "/home/{{ user }}/get_helm.sh"
       mode: '0700'
     retries: 3  
     ignore_errors: yes

--- a/ansible-playbooks/master-replica-playbook.yml
+++ b/ansible-playbooks/master-replica-playbook.yml
@@ -44,9 +44,9 @@
       - containerd.io=1.4.6-1
     when: c_eng == 1
       
-  - name: Add vagrant user to docker group
+  - name: Add user to docker group
     user:
-      name: vagrant
+      name: "{{ user }}"
       group: docker
     when: c_eng == 1
   
@@ -289,17 +289,17 @@
   - name: Multi-master node join command
     command: sh /tmp/join-command.sh
 
-  - name: Setup kubeconfig for vagrant user
+  - name: Setup kubeconfig for user
     command: "{{ item }}"
     with_items:
-     - mkdir -p /home/vagrant/.kube
-     - cp -i /etc/kubernetes/admin.conf /home/vagrant/.kube/config
-     - chown vagrant:vagrant /home/vagrant/.kube/config
+     - "mkdir -p /home/{{ user }}/.kube"
+     - "cp -i /etc/kubernetes/admin.conf /home/{{ user }}/.kube/config"
+     - "chown {{ user }}:{{ user }} /home/{{ user }}/.kube/config"
 
   - name: Install Helm package manager (1/2)
     get_url:
       url: https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
-      dest: /home/vagrant/get_helm.sh
+      dest: "/home/{{ user }}/get_helm.sh"
       mode: '0700'
     retries: 3  
     ignore_errors: yes

--- a/ansible-playbooks/worker-node.yml
+++ b/ansible-playbooks/worker-node.yml
@@ -44,9 +44,9 @@
       - containerd.io=1.4.6-1
     when: c_eng == 1
       
-  - name: Add vagrant user to docker group
+  - name: Add user to docker group
     user:
-      name: vagrant
+      name: "{{ user }}"
       group: docker
     when: c_eng == 1
   


### PR DESCRIPTION
Currently, the user that Ansible writes kubeconfig to is hardcoded to `vagrant`. When deploying this testbed on providers other than Vagrant, this user is missing and thus the playbook fails. For example, in GCP, the user in the image defaults to the Google Account username and in AWS, it defaults to the AMI defined username (e.g. for Ubuntu image it is `ubuntu`).

This PR makes that user reference a variable so that we can change it on-demand.