### PR TITLE
Refactor method of sharing multi master node certificate-key

### DIFF
--- a/ansible-playbooks/master-playbook.yml
+++ b/ansible-playbooks/master-playbook.yml
@@ -361,7 +361,7 @@
 
   - name: Copy join-command for other master nodes
     become: false
-    local_action: copy content="{{ join_command_master }}" dest="./join-command-master"
+    local_action: copy content="{{ join_command_master.stdout_lines[-1] }}" dest="./join-command-master"
     when: n_m_nodes | int > 1
 
   - name: Install Helm package manager (1/2)

--- a/ansible-playbooks/master-replica-playbook.yml
+++ b/ansible-playbooks/master-replica-playbook.yml
@@ -275,15 +275,15 @@
       mode: '0700'
 
   - name: Change join command to join the master node
-    shell: echo $(cat /tmp/join-command) --control-plane --certificate-key $(cut -c225-288 /tmp/join-command-master) --apiserver-advertise-address {{ node_ip }} > /tmp/join-command.sh
+    shell: echo $(cat /tmp/join-command) --control-plane --certificate-key $(cat /tmp/join-command-master) --apiserver-advertise-address {{ node_ip }} > /tmp/join-command.sh
     when: c_eng | int == 1
 
   - name: Change join command to join the master node
-    shell: echo $(cat /tmp/join-command) --control-plane --certificate-key $(cut -c225-288 /tmp/join-command-master) --apiserver-advertise-address {{ node_ip }} --cri-socket=/run/containerd/containerd.sock > /tmp/join-command.sh
+    shell: echo $(cat /tmp/join-command) --control-plane --certificate-key $(cat /tmp/join-command-master) --apiserver-advertise-address {{ node_ip }} --cri-socket=/run/containerd/containerd.sock > /tmp/join-command.sh
     when: c_eng | int == 2
 
   - name: Change join command to join the master node
-    shell: echo $(cat /tmp/join-command) --control-plane --certificate-key $(cut -c225-288 /tmp/join-command-master) --apiserver-advertise-address {{ node_ip }} --cri-socket=/var/run/crio/crio.sock > /tmp/join-command.sh
+    shell: echo $(cat /tmp/join-command) --control-plane --certificate-key $(cat /tmp/join-command-master) --apiserver-advertise-address {{ node_ip }} --cri-socket=/var/run/crio/crio.sock > /tmp/join-command.sh
     when: c_eng | int == 3
 
   - name: Multi-master node join command


### PR DESCRIPTION
Certificate key is always the last line of the output. I've found this method to be more reliable. I believe the referencing `{{ join_command_master }}` would never work, but correct me if I'm wrong.

https://github.com/kubernetes/kubernetes/blob/707b8b6efd1691b84095c9f995f2c259244e276c/cmd/kubeadm/app/cmd/phases/init/uploadcerts.go#L74-L76